### PR TITLE
SPIN-5589: Drop Symfony 5.4 support, add Symfony 7.4 support

### DIFF
--- a/Util/Datatable.php
+++ b/Util/Datatable.php
@@ -97,6 +97,27 @@ class Datatable
     }
 
     /**
+     * Looks up a request parameter the same way the deprecated Request::get()
+     * did: attributes, then query, then request (POST) parameters.
+     */
+    private function _requestGet(Request $request, string $key, mixed $default = null): mixed
+    {
+        if ($request->attributes->has($key))
+        {
+            return $request->attributes->get($key);
+        }
+        if ($request->query->has($key))
+        {
+            return $request->query->get($key);
+        }
+        if ($request->request->has($key))
+        {
+            return $request->request->get($key);
+        }
+        return $default;
+    }
+
+    /**
      * add join
      *
      * @example:
@@ -188,7 +209,7 @@ class Datatable
             });
         }
         $output = array(
-            "sEcho"                => intval($request->get('sEcho')),
+            "sEcho"                => intval($this->_requestGet($request, 'sEcho')),
             "iTotalRecords"        => $total_count,
             "iTotalDisplayRecords" => $total_count,
             "aaData"               => $data

--- a/Util/Factory/Query/DoctrineBuilder.php
+++ b/Util/Factory/Query/DoctrineBuilder.php
@@ -86,6 +86,27 @@ class DoctrineBuilder implements QueryInterface
     }
 
     /**
+     * Looks up a request parameter the same way the deprecated Request::get()
+     * did: attributes, then query, then request (POST) parameters.
+     */
+    private function _requestGet(string $key, mixed $default = null): mixed
+    {
+        if ($this->request->attributes->has($key))
+        {
+            return $this->request->attributes->get($key);
+        }
+        if ($this->request->query->has($key))
+        {
+            return $this->request->query->get($key);
+        }
+        if ($this->request->request->has($key))
+        {
+            return $this->request->request->get($key);
+        }
+        return $default;
+    }
+
+    /**
      * get the search dql
      *
      * @param \Doctrine\ORM\QueryBuilder $queryBuilder
@@ -96,11 +117,10 @@ class DoctrineBuilder implements QueryInterface
     {
         if ($this->search == TRUE)
         {
-            $request       = $this->request;
             $search_fields = array_values($this->fields);
             foreach ($search_fields as $i => $search_field)
             {
-                $search_param = $request->get("sSearch_{$i}");
+                $search_param = $this->_requestGet("sSearch_{$i}");
 
                 $filter = $filter_fields[$i] ?? null;
                 $is_required_date_filter = $filter instanceof DateTimeFilter && $filter->isRequired();
@@ -408,14 +428,14 @@ class DoctrineBuilder implements QueryInterface
      */
     public function addSorting()
     {
-        $request    = $this->request;
         $dql_fields = array_values($this->fields);
+        $sort_col   = $this->_requestGet('iSortCol_0');
 
         // add sorting
-        if ($request->get('iSortCol_0') !== null)
+        if ($sort_col !== null)
         {
 
-            $order_field = current(explode(' as ', $dql_fields[$request->get('iSortCol_0')]));
+            $order_field = current(explode(' as ', $dql_fields[$sort_col]));
         }
         else
         {
@@ -425,14 +445,14 @@ class DoctrineBuilder implements QueryInterface
 
         if ($order_field !== null)
         {
-            $field = $dql_fields[$request->get('iSortCol_0')];
+            $field = $dql_fields[$sort_col];
             if ($field instanceof DQLDatatableField)
             {
-                $qb->orderBy($field->getAlias(), $request->get('sSortDir_0', 'asc'));
+                $qb->orderBy($field->getAlias(), $this->_requestGet('sSortDir_0', 'asc'));
             }
             else
             {
-                $qb->orderBy($order_field, $request->get('sSortDir_0', 'asc'));
+                $qb->orderBy($order_field, $this->_requestGet('sSortDir_0', 'asc'));
             }
         }
         else
@@ -498,8 +518,6 @@ class DoctrineBuilder implements QueryInterface
      */
     public function getData(array $filter_fields=[])
     {
-        $request    = $this->request;
-
         $qb = $this->addSorting();
 
         // extract alias selectors
@@ -527,8 +545,8 @@ class DoctrineBuilder implements QueryInterface
         // add search
         $this->_addSearch($qb, $filter_fields);
 
-        $display_length = (int) $request->get('iDisplayLength');
-        $display_start = (int) $request->get('iDisplayStart');
+        $display_length = (int) $this->_requestGet('iDisplayLength');
+        $display_start = (int) $this->_requestGet('iDisplayStart');
         if($display_length > 10000) //Magic!
         {
             $display_length = 10000;

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "doctrine/orm": ">=2.3",
         "doctrine/dbal": ">=2.13",
         "doctrine/doctrine-bundle": "~1.0|~2.0",
-        "symfony/framework-bundle": "^5.4|^6.4",
-        "symfony/form": "^5.4|^6.4",
-        "symfony/translation": "^5.4|^6.4",
+        "symfony/framework-bundle": "^6.4|^7.4",
+        "symfony/form": "^6.4|^7.4",
+        "symfony/translation": "^6.4|^7.4",
         "shipmonk/doctrine-mysql-index-hints": "^3.0"
     },
     "target-dir": "Ali/DatatableBundle",


### PR DESCRIPTION
Bump symfony/framework-bundle, symfony/form, symfony/translation constraints from ^5.4|^6.4 to ^6.4|^7.4

Fix Request::get() usage in Util/Datatable.php and Util/Factory/Query/DoctrineBuilder.php — deprecated specifically in Symfony 7.4, replaced with a helper that reproduces the same attributes→query→request(POST) lookup so behavior is unchanged